### PR TITLE
Fixes issue of overriding props

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ function install(editor: NodeEditor, params : { component?: Type<any> } = {}) {
         const props: ElementProps = element as any;
 
         props.component = ngComponent.component || params.component || NodeComponent;
-        props.props = Object.assign(ngComponent.props || {}, {
+        props.props = Object.assign({}, ngComponent.props || {}, {
             node,
             editor,
             bindControl,


### PR DESCRIPTION
Absolutely great work on Rete, loving it so far and thanks for all the hard work! 👍 

I encountered an issue when defining custom props on a component. On [line 16](https://github.com/retejs/angular-render-plugin/blob/10bb0b4e0547cdd3e9147832b9d9c5485bfb2dc8/src/index.ts#L16) in `src/index.ts` I saw that you can define props per component, which will then get set on the Angular component (through [line 24](https://github.com/retejs/angular-render-plugin/blob/master/src/custom.component.ts#L24) in `src/custom.component.ts`). I'm using this to define a title and an icon string for my components, which I then use in the Angular component's template to show different title/icons per component type.

The issue there is that the `Object.assign` is overriding `ngComponent.props` every time a new node is rendered, meaning that if you add multiple instances of the same component, `node`, `editor`, etc. are being overridden, and all instances of the same component will now refer to the last added instance's `node`, `editor`, etc. I changed the line to always create a new object instead, i.e. `Object.assign({}, ngComponent.props || {}, { ... });`.
