### PR TITLE
fix: disable Angular Ivy compilation for Angular 10 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,8 @@
       "es2018",
       "dom"
     ]
+  },
+  "angularCompilerOptions": {
+    "enableIvy": false
   }
 }


### PR DESCRIPTION
Follow up of #55 

@Ni55aN The [error](https://github.com/retejs/angular-render-plugin/pull/55#issuecomment-1415860229) you mentioned seems to be related to compilation changes in Angular. 

With this workaround I was able to run both the example in [here](https://github.com/retejs/examples/tree/master/Angular10) (with Node 12) and my Angular 15 project. However, I'm not 100% sure of the implications.